### PR TITLE
Alt tags for images

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
       <section class="steps--container widget--container">
         <article class="steps__article--1 article--widget">
           <h5 lang="en">DAILY STEP GOAL</h5>
-          <canvas id="step-goal-chart"></canvas>
+          <canvas role="img" aria-label="Circular graph to show daily step progress out of overall step goal" id="step-goal-chart"></canvas>
           <p id="step-compare">
           </p>
         </article>
@@ -55,7 +55,7 @@
         <img alt="man sitting on the ground and sweating with weights laying on the ground around him" class="man-icon" src="./images/little-man-icon.svg">
         <article class="hydration__article--2 article--widget">
           <h5 lang="en">WEEKLY OZ</h5>
-          <canvas id="weekly-oz-graph"></canvas>
+          <canvas role="img" aria-label="Bar graph of number of ounces consumed every day for the last week" id="weekly-oz-graph"></canvas>
           <ul id="weekly-oz"></ul>
         </article>
       </section>
@@ -71,7 +71,7 @@
         </article>
         <article class=" sleep__article--2 article--widget">
             <h5 lang="en">YOUR SLEEPING CHART</h5>
-            <canvas id="weekly-sleep"></canvas>
+            <canvas role="img" aria-label="Line graph showing number of hours slept and quality fo sleep for each day from the last week" id="weekly-sleep"></canvas>
         </article>
         <article class="sleep__article--3 article--widget">
           <h5 lang="en">ALL-TIME STATS</h5>
@@ -98,15 +98,15 @@
       <section class="activity--container--2 widget--container">
         <article class="activity__article--3 article--widget">
           <h5 lang="en">WEEKLY STEP COUNT</h5>
-          <canvas id="weekly-steps-chart"></canvas>
+          <canvas role="img" aria-label="Bar graph of number of steps taken every day for the last week" id="weekly-steps-chart"></canvas>
         </article>
         <article class="activity__article--4 article--widget">
           <h5 lang="en">WEEKLY MINUTE COUNT</h5>
-          <canvas id="weekly-minutes-chart"></canvas>
+          <canvas role="img" aria-label="Bar graph of number of minutes active every day for the last week" id="weekly-minutes-chart"></canvas>
         </article>
         <article class="activity__article--5 article--widget">
           <h5 lang="en">WEEKLY FLIGHT COUNT</h5>
-          <canvas id="weekly-flights-chart"></canvas>
+          <canvas role="img" aria-label="Bar graph of number of flights of stairs climbed every day for the last week" id="weekly-flights-chart"></canvas>
         </article>
       </section>
   </main>

--- a/src/index.html
+++ b/src/index.html
@@ -40,7 +40,7 @@
         </article>
         <article class="steps__article--3 article--widget">
           <h5 lang="en">TRENDS</h5>
-          <img class="trend-icon" src="./images/trend-icon.png">
+          <img alt="upward arrow indicating trend" class="trend-icon" src="./images/trend-icon.png">
           <div id="step-trends"></div>
         </article>
       </section>
@@ -50,9 +50,9 @@
       <section class="hydration--container widget--container">
         <article class="hydration__article--1 article--widget" id="daily-oz">
           <h5 lang="en">DAILY OZ</h5>
-          <img class="water-icon" src="./images/water-icon.png">
+          <img alt="white image of drop of water on blue background" class="water-icon" src="./images/water-icon.png">
         </article>
-        <img class="man-icon" src="./images/little-man-icon.svg">
+        <img alt="man sitting on the ground and sweating with weights laying on the ground around him" class="man-icon" src="./images/little-man-icon.svg">
         <article class="hydration__article--2 article--widget">
           <h5 lang="en">WEEKLY OZ</h5>
           <canvas id="weekly-oz-graph"></canvas>
@@ -66,7 +66,7 @@
       <section class="sleep--container widget--container">
         <article class="sleep__article--1 article--widget">
           <h5 lang="en">HOURS SLEPT</h5>
-          <img class="sleep-icon" src="./images/sleep-icon.png">
+          <img alt="yellow waxing crescent moon" class="sleep-icon" src="./images/sleep-icon.png">
           <div id="yesterday-sleep"></div>
         </article>
         <article class=" sleep__article--2 article--widget">
@@ -75,7 +75,7 @@
         </article>
         <article class="sleep__article--3 article--widget">
           <h5 lang="en">ALL-TIME STATS</h5>
-          <img class="trend-icon" src="./images/crown-icon.png">
+          <img alt="yellow crown" class="trend-icon" src="./images/crown-icon.png">
           <div id="all-time-sleep" class="all-time-sleep"></div>
         </article>
       </section>
@@ -85,13 +85,13 @@
       <section class="activity--container--1 widget--container">
         <article class="activity__article--1 article--widget">
           <h5 lang="en">TODAY'S ACTIVITY</h5>
-          <img class="exercise-icon" src="./images/exercise.icon.png">
+          <img alt="stick figure of person running on lime green background" class="exercise-icon" src="./images/exercise.icon.png">
           <div id="daily-activity" class="article__widget--div"></div>
         </article>
-        <img class="step-icon" src="./images/step-icon.png">
+        <img alt="clip art of pink shoe taking a step on a purple background" class="step-icon" src="./images/step-icon.png">
         <article class="activity__article--2 article--widget">
           <h5 lang="en">WORLD COMPARISON</h5>
-          <img class="globe-icon" src="./images/globe-icon.png">
+          <img alt="clipart image of globe" class="globe-icon" src="./images/globe-icon.png">
           <div id="compare-activity"></div>
         </article>
       </section>


### PR DESCRIPTION
#### What's this PR do?
Adds alt tags to all images with a brief description of what the image is.  This way, if a user is using a screen reader, the screen reader is able to provide the listed description of the image.
#### Where should the reviewer start?
Look through the index.html file, and do a cmd + f, locating all <img> tags.  From there, you can see the "alt" descriptions for each one.
#### How should this be manually tested?
You can run an ARIA tester to see the accessibility score increase because of the presence of alt tags.
#### Any background context you want to provide?
It's going to be important to include alt tags for any images that we have.  If we add any more images during this project, we'll want to make sure we're also including alt tags on those pictures, too.
#### What are the relevant tickets?
This PR would close issue #17 
#### Screenshots (if appropriate)
N/A
#### Questions:
Please let me know if you see any other images that we should put an alt tag on!  I looked through the things being appended to the DOM through innerHTML, but there are no additional images we are adding.
Do either of you know how a screen reader interacts with charts?  I don't think there's an alt tag on them to provide additional descriptions, but there may be an equivalent we should add.