### PR TITLE
Add nested describe block for getAverageDay/re-adds test for pos/neg steps

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -277,8 +277,8 @@ function displayFriendSteps(array) {
 }
 
 function displayTrends() {
-  let positiveTrend = activityRepository.getStepTrends('positive').length;
-  let negativeTrend = activityRepository.getStepTrends('negative').length;
+  let positiveTrend = activityRepository.getPositiveStepTrends().length;
+  let negativeTrend = activityRepository.getNegativeStepTrends().length;
   $(`<p lang="en">Since joining you've had:</p> <p><span>${positiveTrend}</span> positive trends</p>`).appendTo(stepTrends);
   $(`<p lang="en"><span>${negativeTrend}</span> negative trends</p>`).appendTo(stepTrends);
 }

--- a/test/Activity-test.js
+++ b/test/Activity-test.js
@@ -108,16 +108,18 @@ describe('ActivityRepository', () => {
     );
   });
 
-  it('should return the average number of stairs climbed for all users on a given date', () => {
-    expect(activityRepository.getAverageDay('2019/08/25', 'flightsOfStairs')).to.equal(90);
-  });
+  describe('getAverageDay', () => {
+    it('should return the average number of stairs climbed for all users on a given date', () => {
+      expect(activityRepository.getAverageDay('2019/08/25', 'flightsOfStairs')).to.equal(90);
+    });
 
-  it('should return the average number of steps taken for all users on a given date', () => {
-    expect(activityRepository.getAverageDay('2019/08/25', 'numSteps')).to.equal(5540);
-  });
+    it('should return the average number of steps taken for all users on a given date', () => {
+      expect(activityRepository.getAverageDay('2019/08/25', 'numSteps')).to.equal(5540);
+    });
 
-  it('should return the average number of minutes active for all users on a given date', () => {
-    expect(activityRepository.getAverageDay('2019/08/25', 'minutesActive')).to.equal(226);
+    it('should return the average number of minutes active for all users on a given date', () => {
+      expect(activityRepository.getAverageDay('2019/08/25', 'minutesActive')).to.equal(226);
+    });
   });
 
   it('should return the number of kilometers a user walked in a given date', () => {
@@ -142,10 +144,10 @@ describe('ActivityRepository', () => {
   });
 
   it('should return the positive trend dates', () => {
-    expect(activityRepository.getStepTrends('positive')).to.deep.equal(['2019/08/20', '2019/08/23'])
+    expect(activityRepository.getPositiveStepTrends()).to.deep.equal(['2019/08/20', '2019/08/23'])
   });
 
   it('should return the negative trend dates', () => {
-    expect(activityRepository.getStepTrends('negative')).to.deep.equal([]);
+    expect(activityRepository.getNegativeStepTrends()).to.deep.equal([]);
   });
 });


### PR DESCRIPTION
**What's this PR do?**
- this branch adds a nested describe block to the getAverageDay method with all 3 paths tested.
- it also re-adds the correct test in for positive and negative step trends 

**Where should the reviewer start?**
- look in the activity test and review the nested describe block

**How should this be manually tested?**
- run NPM test to see changes in the activity test

 **What are the relevant tickets?**
- this will close issue #33  
